### PR TITLE
feat: trim file progress to one line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compare-dir"
-version = "0.6.9"
+version = "0.6.10"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compare-dir"
-version = "0.6.9"
+version = "0.6.10"
 edition = "2024"
 rust-version = "1.88"
 description = "A high-performance directory comparison tool and library"

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 const SPINNER_STYLE: &str = "{elapsed_precise} {spinner:.green} {pos:>7} {msg}";
 const NORMAL_STYLE: &str =
     "{elapsed_precise} +{eta:>3} {percent:>3}% {bar:40.cyan/blue} {pos:>7}/{len:7} {msg}";
-const FILE_STYLE: &str = "  {elapsed:>3} +{eta:>3} {percent:>3}% {msg}";
+const FILE_STYLE: &str = "  {elapsed:>3} +{eta:>3} {percent:>3}% {wide_msg}";
 
 #[derive(Debug)]
 pub(crate) struct Progress {


### PR DESCRIPTION
This avoids scrolling when paths are long.

Also mitigates #16 by avoiding computing heights.
