### PR TITLE
feat: make multi-progress default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -55,10 +55,7 @@ struct Args {
 fn main() -> anyhow::Result<()> {
     let mut args = Args::parse();
     let mut progress = ProgressBuilder::new();
-    if args.verbose >= 1 {
-        progress.is_file_enabled = true;
-        args.verbose -= 1;
-    }
+    progress.is_file_enabled = true;
     init_logger(args.verbose);
     if args.parallel > 0 {
         DirectoryComparer::set_max_threads(args.parallel)?;


### PR DESCRIPTION
Because when all file paths are in one line, it's no longer
too disturbing. Also it mitigates the wide chars issue #16.
