### PR TITLE
feat: make file progress off by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,11 @@ struct Args {
 
 fn main() -> anyhow::Result<()> {
     let mut args = Args::parse();
-    let progress = ProgressBuilder::new();
+    let mut progress = ProgressBuilder::new();
+    if args.verbose > 0 {
+        progress.is_file_enabled = true;
+        args.verbose -= 1;
+    }
     init_logger(args.verbose);
     if args.parallel > 0 {
         DirectoryComparer::set_max_threads(args.parallel)?;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -82,7 +82,7 @@ impl Default for ProgressBuilder {
         Self {
             multi: MultiProgress::default(),
             is_enabled: stderr().is_terminal(),
-            is_file_enabled: true,
+            is_file_enabled: false,
         }
     }
 }


### PR DESCRIPTION
Revert the change in #18, to choose the levels of progress bars.
