### PR TITLE
perf: set max jobs instead of global thread pool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,7 +179,7 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compare-dir"
-version = "0.6.12"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "compare-dir"
-version = "0.6.12"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.88"
 description = "A high-performance directory comparison tool and library"

--- a/src/dir_comparer.rs
+++ b/src/dir_comparer.rs
@@ -39,9 +39,12 @@ pub struct DirectoryComparer {
     pub comparison_method: FileComparisonMethod,
     pub exclude: Option<GlobSet>,
     pub progress: Option<Arc<ProgressBuilder>>,
+    pub jobs: usize,
 }
 
 impl DirectoryComparer {
+    pub const DEFAULT_JOBS: usize = 8;
+
     /// Creates a new `DirectoryComparer` for the two given directories.
     pub fn new(dir1: PathBuf, dir2: PathBuf) -> Self {
         Self {
@@ -52,17 +55,8 @@ impl DirectoryComparer {
             comparison_method: FileComparisonMethod::Hash,
             exclude: None,
             progress: None,
+            jobs: Self::DEFAULT_JOBS,
         }
-    }
-
-    /// Sets the maximum number of threads for parallel processing.
-    /// This initializes the global Rayon thread pool.
-    pub fn set_max_threads(parallel: usize) -> anyhow::Result<()> {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(parallel)
-            .build_global()
-            .map_err(|e| anyhow::anyhow!("Failed to initialize thread pool: {}", e))?;
-        Ok(())
     }
 
     /// Executes the directory comparison and prints results to stdout.
@@ -182,12 +176,12 @@ impl DirectoryComparer {
                 h2.clear_cache()?;
             }
         }
-
-        let mut cur1 = it1.next();
-        let mut cur2 = it2.next();
-        let mut index = 0;
-        tx.send(CompareProgress::StartOfComparison)?;
-        rayon::scope(|scope| {
+        let pool = crate::build_thread_pool(self.jobs)?;
+        pool.scope(|scope| {
+            let mut cur1 = it1.next();
+            let mut cur2 = it2.next();
+            let mut index = 0;
+            tx.send(CompareProgress::StartOfComparison)?;
             loop {
                 let cmp = match (&cur1, &cur2) {
                     (Some((rel1, _)), Some((rel2, _))) => rel1.cmp(rel2),

--- a/src/file_hasher.rs
+++ b/src/file_hasher.rs
@@ -1,4 +1,6 @@
-use crate::{FileComparer, FileHashCache, FileIterator, Progress, ProgressBuilder};
+use crate::{
+    DirectoryComparer, FileComparer, FileHashCache, FileIterator, Progress, ProgressBuilder,
+};
 use globset::GlobSet;
 use std::collections::HashMap;
 use std::fs;
@@ -35,9 +37,12 @@ pub struct FileHasher {
     pub(crate) num_hash_looked_up: AtomicUsize,
     pub exclude: Option<GlobSet>,
     pub progress: Option<Arc<ProgressBuilder>>,
+    pub jobs: usize,
 }
 
 impl FileHasher {
+    const DEFAULT_JOBS: usize = DirectoryComparer::DEFAULT_JOBS;
+
     /// Creates a new `FileHasher` for the given directory.
     pub fn new(dir: PathBuf) -> Self {
         let cache = FileHashCache::find_or_new(&dir);
@@ -49,6 +54,7 @@ impl FileHasher {
             num_hash_looked_up: AtomicUsize::new(0),
             exclude: None,
             progress: None,
+            jobs: Self::DEFAULT_JOBS,
         }
     }
 
@@ -184,8 +190,8 @@ impl FileHasher {
         tx.send(HashProgress::StartDiscovering)?;
         let mut by_size: HashMap<u64, EntryState> = HashMap::new();
         let mut total_hashed = 0;
-
-        rayon::scope(|scope| -> anyhow::Result<()> {
+        let pool = crate::build_thread_pool(self.jobs)?;
+        pool.scope(|scope| -> anyhow::Result<()> {
             let mut it = FileIterator::new(self.dir.clone());
             it.hasher = Some(self);
             it.exclude = self.exclude.as_ref();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,12 @@ pub use progress::ProgressBuilder;
 
 use std::path::{Path, StripPrefixError};
 
+pub(crate) fn build_thread_pool(
+    threads: usize,
+) -> Result<rayon::ThreadPool, rayon::ThreadPoolBuildError> {
+    rayon::ThreadPoolBuilder::new().num_threads(threads).build()
+}
+
 pub(crate) fn human_readable_size(size: u64) -> String {
     const KB: u64 = 1024;
     if size < KB {

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,12 +40,12 @@ struct Args {
     symbol: bool,
 
     /// Buffer size when reading files in KB. If 0, uses mmap.
-    #[arg(long, default_value_t = FileComparer::DEFAULT_BUFFER_SIZE_KB)]
+    #[arg(short = 'B', long, default_value_t = FileComparer::DEFAULT_BUFFER_SIZE_KB)]
     buffer: usize,
 
-    /// Number of parallel threads. If 0, uses the default.
-    #[arg(short, long, default_value_t = 8)]
-    parallel: usize,
+    /// Number of parallel jobs. If 0, uses the default.
+    #[arg(short = 'J', long, default_value_t = DirectoryComparer::DEFAULT_JOBS)]
+    jobs: usize,
 
     /// Enable verbose logging to stderr.
     #[arg(short, long, action = ArgAction::Count)]
@@ -60,9 +60,6 @@ fn main() -> anyhow::Result<()> {
         args.verbose -= 1;
     }
     init_logger(args.verbose);
-    if args.parallel > 0 {
-        DirectoryComparer::set_max_threads(args.parallel)?;
-    }
 
     // Ensure paths are absolute. It helps when computing relative paths and
     // walking ancestors.
@@ -79,6 +76,7 @@ fn main() -> anyhow::Result<()> {
             CompareMethod::Full => FileComparisonMethod::Full,
         };
         comparer.exclude = build_exclude(&args.exclude)?;
+        comparer.jobs = args.jobs;
         comparer.progress = Some(Arc::new(progress));
         comparer.run()
     } else {
@@ -88,6 +86,7 @@ fn main() -> anyhow::Result<()> {
             hasher.clear_cache()?;
         }
         hasher.exclude = build_exclude(&args.exclude)?;
+        hasher.jobs = args.jobs;
         hasher.progress = Some(Arc::new(progress));
         hasher.run()
     }


### PR DESCRIPTION
Change to control the max number of the primary threads, instead of the global thread pool.

It avoids changing the global states, and controls only relevant threads.

It involves:
* `set_max_threads()` is removed.
* The option name is changed to `--jobs` from `--parallel` to reflect what it does better.
